### PR TITLE
Remove PSL URL to remove override

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,3 @@
-psl.url="https://publicsuffix.org/list/public_suffix_list.dat"
 # "file:///Users/.../scalaPSL/src/main/resources/public_suffix_list.dat"
 psl.charset=""
   # "UTF-8"


### PR DESCRIPTION
We want to be able to adjust the public suffix list URL from telescope. However, this line was overriding telescope settings. Removing.